### PR TITLE
Fix Claude model name format for Sonnet 4

### DIFF
--- a/wtf-codebot.yaml
+++ b/wtf-codebot.yaml
@@ -3,7 +3,7 @@
 
 # Anthropic API Configuration
 anthropic_api_key: ""
-anthropic_model: "claude-sonnet-4-0"
+anthropic_model: "claude-sonnet-4-20250514"
 
 # Output Configuration
 output_format: "console" # Options: console, json, markdown

--- a/wtf_codebot/core/config.py
+++ b/wtf_codebot/core/config.py
@@ -103,7 +103,7 @@ class Config(BaseModel):
     
     # API Configuration
     anthropic_api_key: str = Field(..., description="Anthropic API key")
-    anthropic_model: str = Field(default="claude-sonnet-4-0", description="Anthropic model to use")
+    anthropic_model: str = Field(default="claude-sonnet-4-20250514", description="Anthropic model to use")
     
     # Analysis Configuration
     analysis: AnalysisConfig = Field(default_factory=AnalysisConfig)

--- a/wtf_codebot/pattern_recognition/claude_client.py
+++ b/wtf_codebot/pattern_recognition/claude_client.py
@@ -25,7 +25,7 @@ except ImportError:
     # Fallback if config module is not available
     class MockConfig:
         anthropic_api_key = ""
-        anthropic_model = "claude-sonnet-4-0"
+        anthropic_model = "claude-sonnet-4-20250514"
     def get_config():
         return MockConfig()
 


### PR DESCRIPTION
## Description
This PR fixes an issue with the Claude model name format that was causing 404 errors when attempting to use the Claude Sonnet 4 model.

## Changes
- Updated the model name format from `claude-sonnet-4-0` to `claude-sonnet-4-20250514` in:
  - wtf-codebot.yaml
  - wtf_codebot/core/config.py
  - wtf_codebot/pattern_recognition/claude_client.py (MockConfig)

## Testing
Created a test script that verifies the model name is correctly recognized by the Anthropic API. The model now responds successfully instead of returning a 404 error.

## Issue
When attempting to use the Claude Sonnet 4 model, the system was incorrectly formatting the model name as `claude-sonnet-4@20250514` instead of the correct format `claude-sonnet-4-20250514`, resulting in 404 errors from the Anthropic API.

## Additional Notes
The API key should be provided via environment variables rather than being hardcoded in the configuration file.

@beaux-riel can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d3a1d9249a2946ab9d026b66bf7ea6b3)