### PR TITLE
Fix Claude model name format in cost tracker

### DIFF
--- a/wtf_codebot/pattern_recognition/cost_tracker.py
+++ b/wtf_codebot/pattern_recognition/cost_tracker.py
@@ -53,11 +53,11 @@ class CostTracker:
     CLAUDE_PRICING = {
         "claude-3-opus-20240229": {"input": 15.0, "output": 75.0},
         "claude-3-sonnet-20240229": {"input": 3.0, "output": 15.0},
-        "claude-sonnet-4-0": {"input": 3.0, "output": 15.0},
+        "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0},
         "claude-3-haiku-20240307": {"input": 0.25, "output": 1.25},
         "claude-3-5-sonnet-20240620": {"input": 3.0, "output": 15.0},
         "claude-3-5-haiku-20241022": {"input": 0.25, "output": 1.25},
-        "claude-sonnet-4-0": {"input": 0.25, "output": 1.25}
+        "claude-opus-4-20250514": {"input": 15.0, "output": 75.0}
     }
     
     def __init__(self, 
@@ -98,7 +98,7 @@ class CostTracker:
         """
         if model not in self.CLAUDE_PRICING:
             logger.warning(f"Unknown model {model}, using default Sonnet pricing")
-            model = "claude-sonnet-4-0"
+            model = "claude-sonnet-4-20250514"
         
         pricing = self.CLAUDE_PRICING[model]
         input_cost = (input_tokens / 1_000_000) * pricing["input"]


### PR DESCRIPTION
## Description
This PR completes the fix for the Claude model name format issue by updating the model names in the cost tracker module.

## Changes
- Updated the model name format from `claude-sonnet-4-0` to `claude-sonnet-4-20250514` in the cost tracker's `CLAUDE_PRICING` dictionary
- Added pricing for `claude-opus-4-20250514`
- Updated the fallback model name in the `calculate_cost` method

## Issue
After the previous fix (PR #1), the model name was still being transformed incorrectly in some cases. The issue was in the cost tracker module, which was using the old model name format.

## Root Cause
The error message showed that the API was trying to use `claude-sonnet-4@20250514` instead of the correct format `claude-sonnet-4-20250514`. This was happening because the cost tracker was using the old model name format, and the Anthropic client was transforming it incorrectly.

## Testing
The model now responds successfully instead of returning a 404 error.

@beaux-riel can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d3a1d9249a2946ab9d026b66bf7ea6b3)