### PR TITLE
Switch to Claude 3.7 Sonnet model

### DIFF
--- a/wtf-codebot.yaml
+++ b/wtf-codebot.yaml
@@ -3,7 +3,7 @@
 
 # Anthropic API Configuration
 anthropic_api_key: ""
-anthropic_model: "claude-sonnet-4-20250514"
+anthropic_model: "claude-3-7-sonnet-20250219"
 
 # Output Configuration
 output_format: "console" # Options: console, json, markdown

--- a/wtf_codebot/core/config.py
+++ b/wtf_codebot/core/config.py
@@ -103,7 +103,7 @@ class Config(BaseModel):
     
     # API Configuration
     anthropic_api_key: str = Field(..., description="Anthropic API key")
-    anthropic_model: str = Field(default="claude-sonnet-4-20250514", description="Anthropic model to use")
+    anthropic_model: str = Field(default="claude-3-7-sonnet-20250219", description="Anthropic model to use")
     
     # Analysis Configuration
     analysis: AnalysisConfig = Field(default_factory=AnalysisConfig)

--- a/wtf_codebot/pattern_recognition/claude_client.py
+++ b/wtf_codebot/pattern_recognition/claude_client.py
@@ -25,7 +25,7 @@ except ImportError:
     # Fallback if config module is not available
     class MockConfig:
         anthropic_api_key = ""
-        anthropic_model = "claude-sonnet-4-20250514"
+        anthropic_model = "claude-3-7-sonnet-20250219"
     def get_config():
         return MockConfig()
 

--- a/wtf_codebot/pattern_recognition/cost_tracker.py
+++ b/wtf_codebot/pattern_recognition/cost_tracker.py
@@ -53,6 +53,7 @@ class CostTracker:
     CLAUDE_PRICING = {
         "claude-3-opus-20240229": {"input": 15.0, "output": 75.0},
         "claude-3-sonnet-20240229": {"input": 3.0, "output": 15.0},
+        "claude-3-7-sonnet-20250219": {"input": 3.0, "output": 15.0},
         "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0},
         "claude-3-haiku-20240307": {"input": 0.25, "output": 1.25},
         "claude-3-5-sonnet-20240620": {"input": 3.0, "output": 15.0},
@@ -98,7 +99,7 @@ class CostTracker:
         """
         if model not in self.CLAUDE_PRICING:
             logger.warning(f"Unknown model {model}, using default Sonnet pricing")
-            model = "claude-sonnet-4-20250514"
+            model = "claude-3-7-sonnet-20250219"
         
         pricing = self.CLAUDE_PRICING[model]
         input_cost = (input_tokens / 1_000_000) * pricing["input"]


### PR DESCRIPTION
## Description
This PR switches the default model from Claude Sonnet 4 to Claude 3.7 Sonnet to resolve persistent model name format issues.

## Changes
- Updated the model name from `claude-sonnet-4-20250514` to `claude-3-7-sonnet-20250219` in:
  - wtf-codebot.yaml
  - wtf_codebot/core/config.py
  - wtf_codebot/pattern_recognition/claude_client.py (MockConfig)
  - wtf_codebot/pattern_recognition/cost_tracker.py (fallback model)
- Added pricing for `claude-3-7-sonnet-20250219` in the cost tracker's `CLAUDE_PRICING` dictionary

## Issue
Despite previous attempts to fix the model name format for Claude Sonnet 4, the system was still transforming the model name incorrectly, resulting in 404 errors. The error message showed that the API was trying to use `claude-sonnet-4@20250514` instead of the correct format `claude-sonnet-4-20250514`.

## Solution
Switch to using Claude 3.7 Sonnet, which has a more standard model name format that is less likely to be transformed incorrectly. This model is also more stable and widely available.

## Testing
This change should resolve the 404 errors when making API requests to Anthropic.

@beaux-riel can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d3a1d9249a2946ab9d026b66bf7ea6b3)